### PR TITLE
feat(*): add additionalAdjustments prop to AppConfig

### DIFF
--- a/src/generators/SampleAssetsGenerator.ts
+++ b/src/generators/SampleAssetsGenerator.ts
@@ -252,9 +252,11 @@ export class SampleAssetsGenerator {
     private _getAppConfig(config: Config, configImports, configAdditionalImports?) {
         let appConfigTemplate = fs.readFileSync(APP_CONFIG_TEMPLATE_PATH, "utf8");
         let imports = this._getAppConfigImports(config);
+        let additionalAdjustments = this._getAppAdditionalAdjustments(config);
 
         appConfigTemplate = appConfigTemplate
             .replace("{imports}", this._formatImports(imports))
+            .replace("{additionalAdjustments}", additionalAdjustments)
             .replace("{providers}", this._formatProviders(config));
 
         return appConfigTemplate;
@@ -300,6 +302,18 @@ export class SampleAssetsGenerator {
             importMap.set('@angular/router', ['provideRouter', 'withComponentInputBinding']);
         }
         return importMap;
+    }
+
+    private _getAppAdditionalAdjustments(config: Config): string {
+        let additionalAdjustments = "";
+        if (config.appConfig.additionalAdjustments !== undefined &&
+            config.appConfig.additionalAdjustments.length > 0) {
+            let adjustments: string[] = config.appConfig.additionalAdjustments;
+            adjustments.forEach(a => {
+                additionalAdjustments += a + "\n";
+            });
+        }
+        return additionalAdjustments;
     }
 
     private _formatProviders(config: Config) {

--- a/src/public.ts
+++ b/src/public.ts
@@ -40,6 +40,7 @@ export interface AppConfig {
     modules: ModuleProvider[];
     providers: Provider[];
     router?: boolean;
+    additionalAdjustments?: string[];
 }
 
 export class Config {

--- a/src/templates/app.config.ts.template
+++ b/src/templates/app.config.ts.template
@@ -1,4 +1,5 @@
 {imports}
+{additionalAdjustments}
 
 export const AppConfig: ApplicationConfig = {
     providers: [


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-angular-samples/issues/3598

Adds an `additionalAdjustments` property to the `AppConfig` interface.
Before the migration to standalone components, `additionalAdjustments` was part of `AppModuleConfig`, however, as it is no logner used, the former was left out.
With the propsoed implementation, the additional adjustments will be written to the `app.config.ts` file.

Example for the `dock-manager` case and the `defineCustomElements` invocation:

```
//...
import { provideAnimations } from '@angular/platform-browser/animations';
import { defineCustomElements } from 'igniteui-dockmanager/loader';
defineCustomElements();


export const AppConfig: ApplicationConfig = {
    providers: [ 
  //...
```