### PR TITLE
fix: update sample generation for Angular 22 compatibility

### DIFF
--- a/src/generators/SampleAssetsGenerator.ts
+++ b/src/generators/SampleAssetsGenerator.ts
@@ -2,7 +2,7 @@
 // tslint:disable:prefer-const
 import * as fs from "fs";
 import * as path from "path";
-import { DependencyResolver } from "./../services/DependencyResolver";
+import { DependencyResolver, DevDependencyResolver } from "./../services/DependencyResolver";
 
 import { LiveEditingFile, SAMPLE_APP_FOLDER, SAMPLE_SRC_FOLDER } from "./misc/LiveEditingFile";
 import { TsImportsService } from "../services/TsImportsService";
@@ -546,6 +546,14 @@ export class SampleAssetsGenerator {
                 dependenciesString += `,\n    ${replacement}`;
             }
         }
+        // Update devDependencies in the template from the project's devDependencies
+        const devDeps = new DevDependencyResolver().devDependencies;
+        for (const pkg in devDeps) {
+            const escapedPkg = pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const versionPattern = new RegExp(`"${escapedPkg}": "[^"]*"`, 'g');
+            packageJsonFile = packageJsonFile.replace(versionPattern, `"${pkg}": "${devDeps[pkg]}"`);
+        }
+
         // Add packages without resolved versions
         for (const dep of dependencies) {
             if (!withVersions[dep]) {

--- a/src/services/DependencyResolver.ts
+++ b/src/services/DependencyResolver.ts
@@ -25,12 +25,14 @@ const SHARED_DEV_DEPENDENCIES = {
 const DEPENDENCIES_WITH_FIXED_VERSION = {};
 
 const SHARED_DEPENDENCIES = [
+    "@angular/cdk",
     "@angular/common",
     "@angular/compiler",
     "@angular/core",
     "@angular/forms", // included in app.module.ts.template
     "@angular/platform-browser",
     "@angular/platform-browser-dynamic",
+    "@angular/router",
     "rxjs",
     "zone.js",
 

--- a/src/templates/tsconfig.json.template
+++ b/src/templates/tsconfig.json.template
@@ -1,13 +1,11 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
     "esModuleInterop": true,
     "declaration": false,
-    "experimentalDecorators": true,
-    "module": "esnext",
+    "module": "ES2022",
     "moduleResolution": "bundler",
     "importHelpers": true,
     "target": "ES2022",
@@ -17,9 +15,11 @@
     "lib": [
       "es2022",
       "dom"
-    ]
-  },
-  "angularCompilerOptions": {
-    "enableIvy": true
+    ],
+    "skipLibCheck": true,
+    "useDefineForClassFields": false,
+    "strictPropertyInitialization": false,
+    "strictNullChecks": false,
+    "noImplicitAny": false
   }
 }


### PR DESCRIPTION
**Description:**
Fixes StackBlitz/CodeSandbox sample builds failing after Angular 22 upgrade.

- Update tsconfig.json.template — remove deprecated `baseUrl`, `experimentalDecorators`, `enableIvy`; add strict relaxation flags needed by sample code
- Add `@angular/cdk` and `@angular/router` to `SHARED_DEPENDENCIES` for correct version resolution
- Sync devDependencies (`@angular/build`, `@angular/cli`, `typescript`, etc.) from the project into generated sample package.json